### PR TITLE
[16.0][IMP] account_move_export: inject move in parnter._prepare_account_move_partner_code

### DIFF
--- a/account_move_export/models/account_move_line.py
+++ b/account_move_export/models/account_move_line.py
@@ -21,10 +21,10 @@ class AccountMoveLine(models.Model):
             or export_options["partner_option"] == "all"
         ):
             partner_code = self.partner_id._prepare_account_move_export_partner_code(
-                export_options
+                export_options, self
             )
             partner_name = self.partner_id._prepare_account_move_export_partner_name(
-                export_options
+                export_options, self
             )
         res = {
             "type": "G",

--- a/account_move_export/models/res_partner.py
+++ b/account_move_export/models/res_partner.py
@@ -8,7 +8,7 @@ from odoo import models
 class ResPartner(models.Model):
     _inherit = "res.partner"
 
-    def _prepare_account_move_export_partner_code(self, export_options):
+    def _prepare_account_move_export_partner_code(self, export_options, move_line_id):
         self.ensure_one()
         res = None
         if export_options["partner_code_field"] == "id":
@@ -17,6 +17,6 @@ class ResPartner(models.Model):
             res = self.ref or None
         return res
 
-    def _prepare_account_move_export_partner_name(self, export_options):
+    def _prepare_account_move_export_partner_name(self, export_options, move_line_id):
         self.ensure_one()
         return self.name


### PR DESCRIPTION
In custom code, I need to inject here a partner_code different if it's a receivable or payable type.

Having the move_line allows me to check the type of the account