### PR TITLE
backport grouping option in config and export

### DIFF
--- a/account_move_export/i18n/fr.po
+++ b/account_move_export/i18n/fr.po
@@ -519,6 +519,39 @@ msgid "Float"
 msgstr "Nombre décimal"
 
 #. module: account_move_export
+#: model:ir.model.fields,field_description:account_move_export.field_account_move_export_config__group_lines
+msgid "Group Journal Items"
+msgstr "Grouper les écritures comptables"
+
+#. module: account_move_export
+#: model:ir.model.fields,help:account_move_export.field_account_move_export_config__group_lines
+msgid "This option is incompatible with the export of analytic lines."
+msgstr "Cette option est incompatible avec l'export des lignes analytiques."
+
+#. module: account_move_export
+#: model:ir.model.fields,help:account_move_export.field_account_move_export_config__join_char
+msgid ""
+"Character(s) used when joining pieces of text. Used for field 'Taxes' and "
+"for journal entry labels when grouping is enabled."
+msgstr ""
+"Caractère(s) utilisé(s) lors de la concaténation de textes. Utilisé pour le "
+"champ 'Taxes' et pour les libellés d'écritures quand le groupement est activé."
+
+#. module: account_move_export
+#. odoo-python
+#: code:addons/account_move_export/models/account_move_export_config.py:0
+#, python-format
+msgid ""
+"On configuration '%s', the option to group lines is enabled, so you cannot "
+"enable the analytic export. We remind you that the option to group lines is "
+"incompatible with the export of analytic lines."
+msgstr ""
+"Sur la configuration '%s', l'option de groupement des lignes est activée, "
+"vous ne pouvez donc pas activer l'export analytique. Nous vous rappelons que "
+"l'option de groupement des lignes est incompatible avec l'export des lignes "
+"analytiques."
+
+#. module: account_move_export
 #: model:ir.model.fields,field_description:account_move_export.field_account_move_export__message_follower_ids
 msgid "Followers"
 msgstr "Abonnés"
@@ -703,6 +736,11 @@ msgstr "Écritures comptables"
 #, python-format
 msgid "Journal Name"
 msgstr "Nom du journal"
+
+#. module: account_move_export
+#: model:ir.model.fields,field_description:account_move_export.field_account_move_export_config__join_char
+msgid "Join Character(s)"
+msgstr "Caractère(s) de jointure"
 
 #. module: account_move_export
 #: model:ir.model.fields,field_description:account_move_export.field_account_move_export__journal_ids
@@ -1022,6 +1060,13 @@ msgstr ""
 #: model:ir.model.fields,field_description:account_move_export.field_account_move_export__target_move
 msgid "Target Journal Entries"
 msgstr "Écritures cibles"
+
+#. module: account_move_export
+#. odoo-python
+#: code:addons/account_move_export/models/account_move_export_config.py:0
+#, python-format
+msgid "Taxes"
+msgstr "Taxes"
 
 #. module: account_move_export
 #: model:ir.model.fields.selection,name:account_move_export.selection__account_move_export_config__lock__tax

--- a/account_move_export/models/account_move_export.py
+++ b/account_move_export/models/account_move_export.py
@@ -290,21 +290,24 @@ class AccountMoveExport(models.Model):
             domain.append(("state", "in", ("draft", "posted")))
         return domain
 
-    def _prepare_columns(self):
-        cols = []
+    def _prepare_columns(self, export_options):
         number = 0
+        field_dict = self.env["account.move.export.config.column"]._prepare_field_dict()
         for column in self.config_id.column_ids:
-            cols.append(
-                {
-                    "field": column.field,
-                    "field_type": column.field_type,
-                    "excel_width": column.excel_width,
-                    "header_label": column.header_label,
-                    "number": number,
-                }
-            )
+            col_vals = {
+                "field": column.field,
+                "field_type": column.field_type,
+                "excel_width": column.excel_width,
+                "header_label": column.header_label,
+                "number": number,
+            }
+            export_options["cols"].append(col_vals)
+            if col_vals["field_type"] in ("float", "company_currency"):
+                grouping = "sum"
+            else:
+                grouping = field_dict[column.field].get("grouping")
+            export_options["col2grouping"][column.field] = grouping
             number += 1
-        return cols
 
     def _csv_format_amount(self, amount, export_options):
         if not amount:
@@ -342,12 +345,16 @@ class AccountMoveExport(models.Model):
             "header_line": self.config_id.header_line,
             "partner_code_field": self.config_id.partner_code_field,
             "partner_option": self.config_id.partner_option,
+            "group_lines": self.config_id.group_lines,
+            "join_char": self.config_id.join_char,
             "company_currency": self.company_id.currency_id,
             "company_currency_id": self.company_id.currency_id.id,
             "amount_format": f"%.{self.company_id.currency_id.decimal_places}f",
             "analytic_option": self.config_id.analytic_option,
-            "cols": self._prepare_columns(),
+            "cols": [],
+            "col2grouping": {},
         }
+        self._prepare_columns(export_options)
         if self.config_id.analytic_option == "plan_filter":
             export_options[
                 "analytic_plan_ids"
@@ -459,6 +466,55 @@ class AccountMoveExport(models.Model):
         }
         return styles
 
+    def _prepare_moves(self, export_options):
+        self.ensure_one()
+        res = []  # one entry per move. One entry = list of mline_dict
+        for move in self.move_ids:
+            mline_dict_list = []
+            for mline in move.line_ids.filtered(
+                lambda x: x.display_type not in ("line_section", "line_note")
+            ):
+                mline_dict = mline._prepare_account_move_export_line(export_options)
+                mline_dict_list.append(mline_dict)
+            if export_options["group_lines"]:
+                key2mline_dict = {}
+                for mline_dict in mline_dict_list:
+                    key = mline_dict["group_key"]
+                    if key in key2mline_dict:
+                        for col_name, grouping in export_options[
+                            "col2grouping"
+                        ].items():
+                            if grouping == "sum":
+                                key2mline_dict[key][col_name] += mline_dict[col_name]
+                            elif grouping == "concat" and mline_dict[col_name]:
+                                if key2mline_dict[key][col_name]:
+                                    key2mline_dict[key][col_name] = export_options[
+                                        "join_char"
+                                    ].join(
+                                        [
+                                            key2mline_dict[key][col_name],
+                                            mline_dict[col_name],
+                                        ]
+                                    )
+                                else:
+                                    key2mline_dict[key][col_name] = mline_dict[col_name]
+                    else:
+                        key2mline_dict[key] = {"type": mline_dict["type"]}
+                        for col_name in export_options["col2grouping"].keys():
+                            key2mline_dict[key][col_name] = mline_dict[col_name]
+                mline_dict_list_unsorted = list(key2mline_dict.values())
+            else:
+                mline_dict_list_unsorted = mline_dict_list
+            if "account_code" in export_options["col2grouping"]:
+                mline_dict_list_sorted = sorted(
+                    mline_dict_list_unsorted,
+                    key=lambda to_sort: to_sort["account_code"],
+                )
+                res.append(mline_dict_list_sorted)
+            else:
+                res.append(mline_dict_list_unsorted)
+        return res
+
     def _generate_xlsx_generic(self):
         out_file = BytesIO()
         workbook = xlsxwriter.Workbook(out_file)
@@ -474,11 +530,8 @@ class AccountMoveExport(models.Model):
             for col in cols:
                 sheet.write(line, col["number"], col["header_label"], styles["header"])
             line += 1
-        for move in self.move_ids:
-            for mline in move.line_ids.filtered(
-                lambda x: x.display_type not in ("line_section", "line_note")
-            ):
-                mline_dict = mline._prepare_account_move_export_line(export_options)
+        for move in self._prepare_moves(export_options):
+            for mline_dict in move:
                 for col in cols:
                     if col["field"] in mline_dict:
                         sheet.write(
@@ -488,26 +541,16 @@ class AccountMoveExport(models.Model):
                             styles[col["field_type"]],
                         )
                 line += 1
-                if export_options["analytic_option"] == "all":
-                    alines = mline.analytic_line_ids
-                elif export_options["analytic_option"] == "plan_filter":
-                    alines = mline.analytic_line_ids.filtered(
-                        lambda x: x.plan_id.id in export_options["analytic_plan_ids"]
-                    )
-                else:
-                    alines = []
-                for aline in alines:
-                    aline_dict = aline._prepare_account_move_export_line(
-                        export_options
-                    )
-                    for col in cols:
-                        sheet.write(
-                            line,
-                            col["number"],
-                            aline_dict.get(col["field"], "") or "",
-                            styles[f"ana_{col['field_type']}"],
-                        )
-                    line += 1
+                if export_options["analytic_option"] != "no":
+                    for aline_dict in mline_dict.get("analytic_lines", []):
+                        for col in cols:
+                            sheet.write(
+                                line,
+                                col["number"],
+                                aline_dict.get(col["field"], "") or "",
+                                styles[f"ana_{col['field_type']}"],
+                            )
+                        line += 1
 
         workbook.close()
         out_file.seek(0)
@@ -525,24 +568,12 @@ class AccountMoveExport(models.Model):
         )
         if export_options["header_line"]:
             w.writeheader()
-        for move in self.move_ids:
-            for mline in move.line_ids.filtered(
-                lambda x: x.display_type not in ("line_section", "line_note")
-            ):
-                mline_dict = mline._prepare_account_move_export_line(export_options)
+        for move in self._prepare_moves(export_options):
+            for mline_dict in move:
                 row = self._csv_postprocess_line(mline_dict, export_options)
                 w.writerow(row)
-                if export_options["analytic_option"] == "all":
-                    alines = mline.analytic_line_ids
-                elif export_options["analytic_option"] == "plan_filter":
-                    alines = mline.analytic_line_ids.filtered(
-                        lambda x: x.plan_id.id in export_options["analytic_plan_ids"]
-                    )
-                if export_options["analytic_option"] in ("all", "plan_filter"):
-                    for aline in alines:
-                        aline_dict = aline._prepare_account_move_export_line(
-                            export_options
-                        )
+                if export_options["analytic_option"] != "no":
+                    for aline_dict in mline_dict.get("analytic_lines", []):
                         row = self._csv_postprocess_line(aline_dict, export_options)
                         w.writerow(row)
         return self._csv_encode(tmpfile, export_options)

--- a/account_move_export/models/account_move_export_config.py
+++ b/account_move_export/models/account_move_export_config.py
@@ -61,6 +61,17 @@ class AccountMoveExportConfig(models.Model):
         "account.account",
         string="Accounts with Partner",
     )
+    group_lines = fields.Boolean(
+        string="Group Journal Items",
+        help="This option is incompatible with the export of analytic lines.",
+    )
+    join_char = fields.Char(
+        default="-",
+        string="Join Character(s)",
+        required=True,
+        help="Character(s) used when joining pieces of text. "
+        "Used for field 'Taxes' and for journal entry labels when grouping is enabled.",
+    )
     default_journal_ids = fields.Many2many(
         "account.journal",
         string="Default Journals",
@@ -202,6 +213,20 @@ class AccountMoveExportConfig(models.Model):
                         % config.xlsx_analytic_bg_color
                     )
 
+    @api.constrains("group_lines", "analytic_option")
+    def _check_group_lines(self):
+        for config in self:
+            if config.group_lines and config.analytic_option != "no":
+                raise ValidationError(
+                    _(
+                        "On configuration '%s', the option to group lines is "
+                        "enabled, so you cannot enable the analytic export. "
+                        "We remind you that the option to group lines is "
+                        "incompatible with the export of analytic lines."
+                    )
+                    % config.display_name
+                )
+
 
 class AccountMoveExportConfigColumn(models.Model):
     _name = "account.move.export.config.column"
@@ -277,6 +302,7 @@ class AccountMoveExportConfigColumn(models.Model):
                 "width": 25,
                 "type": "char",
             },
+            # grouping for partner and account fields is special, so no "grouping" key
             "account_code": {
                 "label": _("Account Code"),
                 "sequence": 50,
@@ -301,11 +327,19 @@ class AccountMoveExportConfigColumn(models.Model):
                 "width": 30,
                 "type": "char",
             },
+            "tax_names": {
+                "label": _("Taxes"),
+                "sequence": 90,
+                "width": 35,
+                "type": "char",
+                "grouping": "key",
+            },
             "item_label": {
                 "label": _("Journal Item Label"),
                 "sequence": 110,
                 "width": 50,
                 "type": "char",
+                "grouping": "concat",
             },
             "debit": {
                 "label": _("Debit"),
@@ -336,12 +370,14 @@ class AccountMoveExportConfigColumn(models.Model):
                 "sequence": 160,
                 "width": 20,
                 "type": "char",
+                "grouping": "key",
             },
             "due_date": {
                 "label": _("Due Date"),
                 "sequence": 170,
                 "width": 10,
                 "type": "date",
+                "grouping": "key",
             },
             "origin_currency_amount": {
                 "label": _("Origin Currency Amount"),
@@ -354,6 +390,7 @@ class AccountMoveExportConfigColumn(models.Model):
                 "sequence": 190,
                 "width": 9,
                 "type": "char",
+                "grouping": "key",
             },
         }
         line_obj = self.env["account.move.line"]
@@ -365,12 +402,14 @@ class AccountMoveExportConfigColumn(models.Model):
                         "sequence": 200,
                         "width": 10,
                         "type": "date",
+                        "grouping": "key",
                     },
                     "end_date": {
                         "label": _("End Date"),
                         "sequence": 210,
                         "width": 10,
                         "type": "date",
+                        "grouping": "key",
                     },
                 }
             )

--- a/account_move_export/models/account_move_line.py
+++ b/account_move_export/models/account_move_line.py
@@ -49,6 +49,9 @@ class AccountMoveLine(models.Model):
             "account_name": self.account_id.name,
             "partner_code": partner_code,
             "partner_name": partner_name,
+            "tax_names": self.tax_ids
+            and export_options["join_char"].join([t.name for t in self.tax_ids])
+            or None,
             "item_label": self.name or None,
             "debit": export_options["company_currency"].round(self.debit),
             "credit": export_options["company_currency"].round(self.credit),
@@ -66,4 +69,32 @@ class AccountMoveLine(models.Model):
                     "end_date": self.end_date or None,
                 }
             )
+        if not export_options["group_lines"] and export_options["analytic_option"] != "no":
+            res["analytic_lines"] = []
+            if export_options["analytic_option"] == "all":
+                alines = self.analytic_line_ids
+            elif export_options["analytic_option"] == "plan_filter":
+                alines = self.analytic_line_ids.filtered(
+                    lambda x: x.plan_id.id in export_options["analytic_plan_ids"]
+                )
+            else:
+                alines = []
+            for aline in alines:
+                aline_dict = aline._prepare_account_move_export_line(export_options)
+                if aline_dict:
+                    res["analytic_lines"].append(aline_dict)
+        if export_options["group_lines"]:
+            group_key2value = {"account_code": res["account_code"]}
+            for col_name, grouping in export_options["col2grouping"].items():
+                if grouping == "key":
+                    group_key2value[col_name] = str(res[col_name])
+                elif col_name in ("partner_code", "partner_name"):
+                    group_key2value["partner_id"] = str(self.partner_id.id or None)
+                elif col_name == "origin_currency_amount":
+                    # anyway, if 'origin_currency_amount' is in cols,
+                    # 'origin_currency_code' should be in cols too, but just in case
+                    group_key2value["origin_currency_code"] = res[
+                        "origin_currency_code"
+                    ]
+            res["group_key"] = "-".join(list(group_key2value.values()))
         return res

--- a/account_move_export/views/account_move_export_config.xml
+++ b/account_move_export/views/account_move_export_config.xml
@@ -37,6 +37,7 @@
                             name="header_line"
                             attrs="{'invisible': [('file_format', 'not in', ('csv_generic', 'xlsx_generic'))]}"
                         />
+                        <field name="group_lines"/>
                         <field
                             name="analytic_option"
                             groups="analytic.group_analytic_accounting"
@@ -56,6 +57,7 @@
                             widget="many2many_tags"
                             attrs="{'required': [('partner_option', '=', 'accounts')], 'invisible': [('partner_option', '!=', 'accounts')]}"
                                 />
+                        <field name="join_char"/>
                         <field name="suspense_account_raise"/>
                         <field name="lock" widget="radio" />
                         <field name="company_id" groups="base.group_multi_company" />
@@ -117,6 +119,7 @@
                     <field name="name" decoration-bf="1" />
                     <field name="file_format" optional="show" />
                     <field name="zip_with_attachments" optional="show" />
+                    <field name="group_lines" optional="show" />
                     <field name="partner_option" optional="show" />
                     <field name="partner_code_field" optional="show" />
                     <field


### PR DESCRIPTION
For a client installation on V16, we needed the option to group entries. We therefore backported the work done on the V18 branch to V16 and would like to share it in case other users need it.
Thanks for this module—it’s awesome!