### PR TITLE
[FIX] account_move_export: adapt domain to date_range company_ids field

### DIFF
--- a/account_move_export/models/account_move_export.py
+++ b/account_move_export/models/account_move_export.py
@@ -66,7 +66,7 @@ class AccountMoveExport(models.Model):
     date_range_id = fields.Many2one(
         "date.range",
         check_company=True,
-        domain="[('company_id', 'in', (company_id, False))]",
+        domain="[('company_ids', 'in', [company_id, False])]",
     )
     date_start = fields.Date(
         compute="_compute_dates",


### PR DESCRIPTION
## Context
The `date_range` module (OCA/server-ux) changed the `company_id` field from `Many2one` to `company_ids` (`Many2many`) in version 18.0 to support multi-company scenarios.

This change breaks the installation of `account_move_export` module when using the updated version of `date_range`.

## Issue
When installing `account_move_export` with the updated `date_range` module, the following error occurs:
```python
odoo.tools.convert.ParseError: while parsing /path/to/account_move_export/views/account_move_export.xml:10

Champ inconnu "date.range.company_id" dans domain of python field 'date_range_id' 
((company_id and [('company_id', 'in', [company_id] + [False])] or [('company_id', '=', False)]) + ([('company_id', 'in', (company_id, False))]))
```

## Solution
This PR updates the domain on the `date_range_id` field in the `account.move.export` model to use `company_ids` instead of `company_id`.

### Changes
- **Before:** `domain="[('company_id', 'in', (company_id, False))]"`
- **After:** `domain="[('company_ids', 'in', [company_id, False])]"`
